### PR TITLE
fluid: add a button to make the widget panel stay on top.

### DIFF
--- a/fluid/widget_panel.cxx
+++ b/fluid/widget_panel.cxx
@@ -21,6 +21,8 @@
 #include "widget_panel.h"
 extern void comment_cb(Fl_Text_Editor*, void*);
 
+Fl_Double_Window *pWnd_Widget=(Fl_Double_Window *)0;
+
 static void cb_(Fl_Tabs* o, void* v) {
   propagate_load((Fl_Group *)o,v);
 }
@@ -86,19 +88,25 @@ Fl_Text_Editor *wComment=(Fl_Text_Editor *)0;
 
 CodeEditor *wCallback=(CodeEditor *)0;
 
+Fl_Button *pCk_OnTop=(Fl_Button *)0;
+
+static void cb_pCk_OnTop(Fl_Button*, void*) {
+  pWnd_Widget->hide();
+pWnd_Widget->set_non_modal();
+pWnd_Widget->show();
+}
+
 Fl_Button *wLiveMode=(Fl_Button *)0;
 
 /**
  Create a panel that can be used with all known widgets
 */
 Fl_Double_Window* make_widget_panel() {
-  Fl_Double_Window* w;
   { // Use a Double Window to avoid flickering.
-    Fl_Double_Window* o = new Fl_Double_Window(420, 400);
-    w = o; if (w) {/* empty */}
-    o->labelsize(11);
-    o->align(Fl_Align(FL_ALIGN_CLIP|FL_ALIGN_INSIDE));
-    o->hotspot(o);
+    Fl_Double_Window* o = pWnd_Widget = new Fl_Double_Window(420, 400);
+    pWnd_Widget->labelsize(11);
+    pWnd_Widget->align(Fl_Align(FL_ALIGN_CLIP|FL_ALIGN_INSIDE));
+    pWnd_Widget->hotspot(pWnd_Widget);
     { Fl_Tabs* o = new Fl_Tabs(10, 10, 400, 350);
       o->selection_color((Fl_Color)12);
       o->labelsize(11);
@@ -825,8 +833,15 @@ access the Widget pointer and \'v\' to access the user value.");
     } // Fl_Tabs* o
     { Fl_Group* o = new Fl_Group(10, 370, 400, 20);
       o->labelsize(11);
+      { pCk_OnTop = new Fl_Button(10, 370, 65, 20, "On Top");
+        pCk_OnTop->tooltip("Click to make the \"Properties\" window (this window)\nstay on top of the cur\
+rently active window.");
+        pCk_OnTop->down_box(FL_DOWN_BOX);
+        pCk_OnTop->labelsize(11);
+        pCk_OnTop->callback((Fl_Callback*)cb_pCk_OnTop);
+      } // Fl_Button* pCk_OnTop
       { // Hidden resizable box
-        Fl_Box* o = new Fl_Box(10, 370, 75, 20);
+        Fl_Box* o = new Fl_Box(80, 370, 5, 20);
         o->labelsize(11);
         o->hide();
         Fl_Group::current()->resizable(o);
@@ -863,10 +878,10 @@ avior.");
       o->end();
     } // Fl_Group* o
     o->size_range(o->w(), o->h());
-    o->size_range(420, 400);
-    o->end();
-  } // Fl_Double_Window* o
-  return w;
+    pWnd_Widget->size_range(420, 400);
+    pWnd_Widget->end();
+  } // Fl_Double_Window* pWnd_Widget
+  return pWnd_Widget;
 }
 
 //

--- a/fluid/widget_panel.fl
+++ b/fluid/widget_panel.fl
@@ -28,7 +28,7 @@ decl {extern void comment_cb(Fl_Text_Editor*, void*);} {private global
 Function {make_widget_panel()} {
   comment {Create a panel that can be used with all known widgets} open
 } {
-  Fl_Window {} {
+  Fl_Window pWnd_Widget {
     comment {Use a Double Window to avoid flickering.} open
     xywh {560 60 420 400} type Double labelsize 11 align 80 resizable hotspot
     code0 {o->size_range(o->w(), o->h());} size_range {420 400 0 0} visible
@@ -668,9 +668,18 @@ wCallback->do_callback(wCallback, v);} open
     Fl_Group {} {open
       xywh {10 370 400 20} labelsize 11
     } {
+      Fl_Button pCk_OnTop {
+        label {On Top}
+        callback {pWnd_Widget->hide();
+pWnd_Widget->set_non_modal();
+pWnd_Widget->show();}
+        tooltip {Click to make the "Properties" window (this window)
+stay on top of the currently active window.} xywh {10 370 65 20} down_box DOWN_BOX labelsize 11
+        code0 {\#include <FL/Fl.H>}
+      }
       Fl_Box {} {
         comment {Hidden resizable box}
-        xywh {10 370 75 20} labelsize 11 hide resizable
+        xywh {80 370 5 20} labelsize 11 hide resizable
       }
       Fl_Button {} {
         label Revert

--- a/fluid/widget_panel.h
+++ b/fluid/widget_panel.h
@@ -22,6 +22,7 @@
 #define widget_panel_h
 #include <FL/Fl.H>
 #include <FL/Fl_Double_Window.H>
+extern Fl_Double_Window *pWnd_Widget;
 #include <FL/Fl_Tabs.H>
 #include <FL/Fl_Group.H>
 extern void propagate_load(Fl_Group*, void*);
@@ -102,6 +103,7 @@ extern Fl_Menu_Item whenmenu[];
 extern void when_cb(Fl_Choice*, void*);
 extern void user_data_type_cb(Fl_Input*, void*);
 extern void when_button_cb(Fl_Light_Button*, void*);
+extern Fl_Button *pCk_OnTop;
 extern void revert_cb(Fl_Button*, void*);
 extern void live_mode_cb(Fl_Button*, void*);
 extern Fl_Button *wLiveMode;


### PR DESCRIPTION
Makes the widget panel 'non-modal' to the previously shown or active
window. This can be used to have the widget panel always on top of
the 'edit window' (the window that is worked on).